### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Install a typical Centos7 with following parameters:
     $ mkdir /var/log/renat
     $ chown root:renat /var/log/renat
     $ chmod 0775 /var/log/renat
-    ``
+    ```
 
     - add setting for renat to the end of `/etc/rsyslog.conf`
 


### PR DESCRIPTION
` is missing from line 296 and broke formatting for few lines below it.

That's how it is now: https://imgur.com/a/FLpzaAV
And that's how it would be after the change: https://imgur.com/a/BMMZi8j