### PR TITLE
fix: correct occured->occurred typo in Fic.py log message

### DIFF
--- a/Fic.py
+++ b/Fic.py
@@ -315,7 +315,7 @@ class Fic(WebApp):
         """
         self.capture_screenshot(extra="_failure")
         self.close()
-        BuiltIn().log("A failure has been occured, quit the browser")
+        BuiltIn().log("A failure has been occurred, quit the browser")
 
 
     def close(self):


### PR DESCRIPTION
Fix a typo in the browser failure log message.

- `occured` → `occurred` in Fic.py line 318
- User-visible Robot Framework log message